### PR TITLE
add #[\ReturnTypeWillChange] attribute to suppress PHP notices

### DIFF
--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -11,6 +11,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
 {
   protected $collection_key = 'items';
 
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     if (is_array($this->modelData[$this->collection_key])) {
@@ -18,6 +19,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function current()
   {
     $this->coerceType($this->key());
@@ -26,6 +28,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function key()
   {
     if (is_array($this->modelData[$this->collection_key])) {
@@ -33,17 +36,20 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function next()
   {
     return next($this->modelData[$this->collection_key]);
   }
 
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     $key = $this->key();
     return $key !== null && $key !== false;
   }
 
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return count($this->modelData[$this->collection_key]);

--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -198,11 +198,13 @@ class Google_Model implements ArrayAccess
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     return isset($this->$offset) || isset($this->modelData[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     return isset($this->$offset) ?
@@ -210,6 +212,7 @@ class Google_Model implements ArrayAccess
         $this->__get($offset);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     if (property_exists($this, $offset)) {
@@ -220,6 +223,7 @@ class Google_Model implements ArrayAccess
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     unset($this->modelData[$offset]);


### PR DESCRIPTION
@DavidAnderson684 I've managed to recreate the deprecation notices. I've been getting these in my PHP error log file when running the API on PHP 8.1:

![image](https://user-images.githubusercontent.com/400912/192812622-b0f4921d-f103-4077-b858-4999adcc2903.png)

I can confirm that changes in this PR temporarily suppresses and gets rid of the deprecation notices.